### PR TITLE
feat: unpack terraform binaries directly to /usr/bin directory

### DIFF
--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -19,15 +19,22 @@ runs:
     - name: Install Terraform v${{ inputs.terraform-version }}
       shell: bash
       run: |
-        curl -sO https://releases.hashicorp.com/terraform/${{ inputs.terraform-version }}/terraform_${{ inputs.terraform-version }}_linux_amd64.zip
-        unzip -qq terraform_${{ inputs.terraform-version }}_linux_amd64.zip && rm terraform_${{ inputs.terraform-version }}_linux_amd64.zip 2> /dev/null && sudo mv terraform /usr/bin/
+        curl -sSO https://releases.hashicorp.com/terraform/${{ inputs.terraform-version }}/terraform_${{ inputs.terraform-version }}_linux_amd64.zip
+        sudo unzip -qq terraform_${{ inputs.terraform-version }}_linux_amd64.zip terraform -d /usr/bin/
+        rm terraform_${{ inputs.terraform-version }}_linux_amd64.zip 2> /dev/null
 
     - name: Install pre-commit dependencies
       shell: bash
       run: |
         pip install -q pre-commit
-        curl -sLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${{ inputs.terraform-docs-version }}/terraform-docs-${{ inputs.terraform-docs-version }}-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-        curl -sL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip -qq tflint.zip && rm tflint.zip 2> /dev/null && sudo mv tflint /usr/bin/
+
+        curl -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${{ inputs.terraform-docs-version }}/terraform-docs-${{ inputs.terraform-docs-version }}-$(uname)-amd64.tar.gz
+        sudo tar -xzf terraform-docs.tar.gz terraform-docs -C /usr/bin/
+        rm terraform-docs.tar.gz 2> /dev/null
+
+        curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip
+        sudo unzip -qq tflint.zip tflint -d /usr/bin/
+        rm tflint.zip 2> /dev/null
 
     - name: Execute pre-commit
       shell: bash


### PR DESCRIPTION
## Description

The `clowdhaus/terraform-composite-actions/pre-commit` action currently
downloads and unpacks terraform and related binaries into the current
working directory and then subsequently moves them into /usr/bin. In a
somewhat contrived (but real) scenario where a GitHub repo already has
a `terraform` directory, unzip will fail since we cannot unzip a binary
on top of a directory with the same name.

With this change, binaries are unpacked directly to the /usr/bin
directory via either

* unzip -qq <source.zip> <target file> -d /usr/bin
* tar -xzf <source.tgz> <target file> -C /usr/bin

These are unpacked with `sudo` in order to be able to write to the
/usr/bin directory. I've also removed the `chmod +x` step for
terraform-docs as it appears to already have the execute bit set on it.

## Motivation and Context

Unfortunately I have at least one such contrived case of GitHub repos
with `terraform` directories already present!

## How Has This Been Tested?

I'm successfully consuming this patch by targeting the patch in a workflow via

```yaml
- name: Pre-commit Terraform ${{ matrix.version }}
  uses: byronwolfman/terraform-composite-actions/pre-commit@ee4ed66580ed8a5320b194f7e40a4437c62d76d5
```

The linter found all kinds of problems, which is what I had hoped it
would do! That is to say, the linter (and action) works.

## Screenshots (if appropriate):

![Screen Shot 2022-01-06 at 7 46 25 PM](https://user-images.githubusercontent.com/11906832/148468415-ee09c7c5-941a-41fb-8dba-632a2becec9e.png)

