### PR TITLE
fix: untar re-order untar args so terraform-docs is installed

### DIFF
--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -29,7 +29,7 @@ runs:
         pip install -q pre-commit
 
         curl -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${{ inputs.terraform-docs-version }}/terraform-docs-${{ inputs.terraform-docs-version }}-$(uname)-amd64.tar.gz
-        sudo tar -xzf terraform-docs.tar.gz terraform-docs -C /usr/bin/
+        sudo tar -xzf terraform-docs.tar.gz -C /usr/bin/ terraform-docs
         rm terraform-docs.tar.gz 2> /dev/null
 
         curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip


### PR DESCRIPTION
## Description

In a previous commit, I changed the way that various terraform binaries
were unpacked so that they would install directly into /usr/bin rather
than staging in cwd and then moved. Unfortunately this did not work for
terraform-docs as I put the arguments in the wrong order. The -C flag is
order-sensitive as described in the man page, and affects all options
that follow.

This fix moves the `-C /usr/bin/` flag ahead of the file being untar'd
so that it is correctly changes directories prior to terraform-docs
being unpacked.

Sorry about that and hopefully everyone with dependabot will end up
skipping the broken version I PR'd the other night.

## Motivation and Context

To fix a bug I created in https://github.com/clowdhaus/terraform-composite-actions/pull/2 😬 

## How Has This Been Tested?

More comprehensively this time! The bug escaped notice the first time
because it did not attempt to execute terraform-docs, and only tried to
execute terraform and tflint.

I have re-tested with a pre-commit config requiring all three binaries
to be executed this time, which succeeds when pointed to my forked
branch.

## Screenshots (if appropriate):

<img width="789" alt="Screen Shot 2022-01-07 at 6 11 04 PM" src="https://user-images.githubusercontent.com/11906832/148614006-b88b0b06-bf80-42d9-b75e-286428142c47.png">
