### PR TITLE
feat: Add support for optionally installing `hcledit` in `pre-commit` workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  HCLEDIT_VERSION: 0.2.3
 
 jobs:
   collectInputs:
@@ -17,7 +18,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get root directories
         id: dirs
@@ -32,11 +33,11 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.4
+        uses: clowdhaus/terraform-min-max@v1.0.8
         with:
           directory: ${{ matrix.directory }}
 
@@ -62,17 +63,22 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.4
+        uses: clowdhaus/terraform-min-max@v1.0.8
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: ./pre-commit
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          install-hcledit: true
+          hcledit-version: ${{ env.HCLEDIT_VERSION }}
+
+      - name: check
+        run: hcledit --help

--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Release
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ jobs:
       - name: Sign AWS Lambda artifact
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
-          terraform-version: 1.0.2
-          terraform-docs-version: v15.0.0
+          terraform-version: 1.2.0
+          terraform-docs-version: v16.0.0
+          install-hcledit: true
+          hcledit-version: 0.2.3
           args: "--all-files --color always --show-diff-on-failure"
 ```
 

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -13,6 +13,7 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 - [pre-commit](https://github.com/pre-commit/pre-commit)
 - [tflint](https://github.com/terraform-linters/tflint)
 - [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input
+- [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit` is `true` (and `hcledit-version` to support)
 
 ```yml
 jobs:
@@ -23,7 +24,9 @@ jobs:
       - name: Sign AWS Lambda artifact
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
-          terraform-version: 1.0.2
-          terraform-docs-version: v15.0.0
+          terraform-version: 1.2.0
+          terraform-docs-version: v16.0.0
+          install-hcledit: true
+          hcledit-version: 0.2.3
           args: "--all-files --color always --show-diff-on-failure"
 ```

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -12,6 +12,14 @@ inputs:
     description: Arguments to pass to pre-commit
     required: false
     default: '--all-files --color always --show-diff-on-failure'
+  install-hcledit:
+    description: Install hcledit for pre-commit
+    required: false
+    default: 'false'
+  hcledit-version:
+    description: Version of hcledit to install when `install-hcledit` is true
+    required: false
+    default: 0.2.3
 
 runs:
   using: composite
@@ -35,6 +43,12 @@ runs:
         curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip
         sudo unzip -qq tflint.zip tflint -d /usr/bin/
         rm tflint.zip 2> /dev/null
+
+        if [[ "${{ inputs.install-hcledit }}" == "true" ]]; then
+          curl -sSLo ./hcledit.tar.gz https://github.com/minamijoyo/hcledit/releases/download/v${{ inputs.hcledit-version }}/hcledit_${{ inputs.hcledit-version }}_$(uname)_amd64.tar.gz
+          sudo tar -xzf hcledit.tar.gz -C /usr/bin/ hcledit
+          rm hcledit.tar.gz 2> /dev/null
+        fi
 
     - name: Execute pre-commit
       shell: bash


### PR DESCRIPTION
## Description
- Add support for optionally installing `hcledit` in `pre-commit` workflow

## Motivation and Context
- Allows users to opt in to using `hcledit` in pre-commit workflow for Terragrunt wrapper support

## How Has This Been Tested?
- CI checks on PR

## Screenshots (if appropriate):
