### PR TITLE
feat(pre-commit): Support pinned tflint versions

### DIFF
--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Version of terraform-docs to use when evaluating checks
     required: false
     default: v0.16.0
+  tflint-version:
+    description: Version of tflint to use when evaluating checks
+    required: false
+    default: latest
   args:
     description: Arguments to pass to pre-commit
     required: false
@@ -40,7 +44,11 @@ runs:
         sudo tar -xzf terraform-docs.tar.gz -C /usr/bin/ terraform-docs
         rm terraform-docs.tar.gz 2> /dev/null
 
-        curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip
+        if [[ "${{ inputs.tflint-version }}" == "latest" ]]; then
+          curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip
+        else
+          curl -sSLo ./tflint.zip https://github.com/terraform-linters/tflint/releases/download/${{ inputs.tflint-version }}/tflint_linux_amd64.zip
+        fi
         sudo unzip -qq tflint.zip tflint -d /usr/bin/
         rm tflint.zip 2> /dev/null
 


### PR DESCRIPTION
## Description
Add an optional input variable to pin the version of tflint to a specific release

## Motivation and Context
This fixes #7, and as noted there, addresses an issue where new releases that update the client version can cause checks to break when a given project is using an older plugin version in the tflint.hcl configuration.

## How Has This Been Tested?
I checked the shell code locally to ensure that it would appropriately download the pinned version id, but I have not done further testing, including testing in a GitHub actions environment. 

