### PR TITLE
fix: Remove default version of `terraform` if present on the host before installing intended version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Default Terraform version
+        continue-on-error: true
+        run: terraform version
+
       - name: Terraform min/max versions
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.8
@@ -57,6 +61,9 @@ jobs:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
+      - name: Selected Terraform version
+        run: terraform version
+
   preCommitMaxVersion:
     name: Max TF pre-commit
     runs-on: ubuntu-latest
@@ -67,6 +74,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Default Terraform version
+        continue-on-error: true
+        run: terraform version
 
       - name: Terraform min/max versions
         id: minMax
@@ -82,3 +93,6 @@ jobs:
 
       - name: check
         run: hcledit --help
+
+      - name: Selected Terraform version
+        run: terraform version

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -39,6 +39,7 @@ runs:
     - name: Install Terraform v${{ inputs.terraform-version }}
       shell: bash
       run: |
+        rm -rf $(which terraform)
         curl -sSO https://releases.hashicorp.com/terraform/${{ inputs.terraform-version }}/terraform_${{ inputs.terraform-version }}_linux_amd64.zip
         sudo unzip -qq terraform_${{ inputs.terraform-version }}_linux_amd64.zip terraform -d /usr/bin/
         rm terraform_${{ inputs.terraform-version }}_linux_amd64.zip 2> /dev/null


### PR DESCRIPTION
## Description
- Remove default version of `terraform` if present on the host before installing intended version

## Motivation and Context
- Resolves #9 ; we have been using something similar https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/0529549fa2f4b07f65c199c2573b81b2e979aa56/.github/workflows/pre-commit.yaml#L45

## How Has This Been Tested?
- CI

## Screenshots (if appropriate):
