### PR TITLE
feat: Update output syntax to replace deprecated method warnings

### DIFF
--- a/directories/action.yml
+++ b/directories/action.yml
@@ -13,4 +13,4 @@ runs:
       id: search
       run: |
         DIRS=$(python -c "import json; import glob; import re; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True) if not re.match(r'^.+/_', x)]))")
-        echo "::set-output name=directories::$DIRS"
+        echo "directories=$DIRS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
- Correct output syntax to replaced deprecated method

## Motivation and Context
- Removes warnings generated by the action
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

## How Has This Been Tested?
- CI checks

## Screenshots (if appropriate):
