### PR TITLE
feat: Bump default `hcledit` version to latest; fix CI release process by updating action versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get root directories
         id: dirs
@@ -33,7 +33,7 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Default Terraform version
         continue-on-error: true
@@ -41,7 +41,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v1.3.0
         with:
           directory: ${{ matrix.directory }}
 
@@ -70,7 +70,7 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v1.3.0
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: ./pre-commit

--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: '20.x'
 
       - name: Release
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.88.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -27,3 +27,4 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -31,7 +31,7 @@ inputs:
   tfsec-version:
     description: Version of tfsec to install when `install-tfsec` is true
     required: false
-    default: 1.28.4
+    default: 1.28.5
 
 runs:
   using: composite


### PR DESCRIPTION
## Description
- Bump default `hcledit` version to latest
- Fix CI release process by updating action versions

## Motivation and Context
- Fix failing CI to create new release

## How Has This Been Tested?
- CI

## Screenshots (if appropriate):
