### PR TITLE
fix: resolve pip install environment error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -67,9 +67,16 @@ runs:
         sudo unzip -qq terraform_${{ inputs.terraform-version }}_${{ env.OS }}_${{ env.ARCH }}.zip terraform -d /usr/bin/
         rm terraform_${{ inputs.terraform-version }}_${{ env.OS }}_${{ env.ARCH }}.zip 2> /dev/null
 
+    - name: Setup python venv
+      shell: bash
+      run: |
+        mkdir -p ~/.venv
+        python3 -m venv ~/.venv
+
     - name: Install pre-commit dependencies
       shell: bash
       run: |
+        source ~/.venv/bin/activate
         pip install -q pre-commit
 
         curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${{ inputs.terraform-docs-version }}/terraform-docs-${{ inputs.terraform-docs-version }}-${{ env.OS }}-${{ env.ARCH }}.tar.gz
@@ -99,4 +106,12 @@ runs:
 
     - name: Execute pre-commit
       shell: bash
-      run: pre-commit run ${{ inputs.args }}
+      run: |
+        source ~/.venv/bin/activate
+        pre-commit run ${{ inputs.args }}
+
+    - name: Cleanup venv
+      shell: bash
+      run: |
+        rm -rf .venv # tidy up
+

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -114,4 +114,3 @@ runs:
       shell: bash
       run: |
         rm -rf .venv # tidy up
-


### PR DESCRIPTION
## Description
Closes #22

## Motivation and Context
We began to see errors stating:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.
```

## How Has This Been Tested?

Updated our internal CI to use:

```yaml
      - name: ...
        uses: peter-mcconnell/terraform-composite-actions/pre-commit@main
        with:
          terraform-version: ${{ steps.minMax.outputs.maxVersion }}
          tflint-version: ${{ env.TFLINT_VERSION }}
          terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
          install-hcledit: true
```

And confirmed it worked successfully

## Screenshots (if appropriate):
