### PR TITLE
feat: Support installing `trivy` for `pre-commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 #### Optional
 
 - [tfsec](https://aquasecurity.github.io/tfsec), when `install-tfsec=true` (default = `false`), using provided `tfsec-version` input (default = `1.28.0`)
+- [trivy](https://aquasecurity.github.io/trivy), when `install-trivy=true` (default = `false`), using provided `trivy-version` input (default = `0.65.0`)
 - [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit=true` (default = `false`), using provided `hcledit-version` input (default = `0.2.3`)
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 - [pre-commit](https://github.com/pre-commit/pre-commit)
 - [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required)
 - [tflint](https://github.com/terraform-linters/tflint) using provided `tflint-version` input (default = `latest`)
-- [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input (default = `v0.16.0`)
+- [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input (default = `v0.20.0`)
 
 #### Optional
 
-- [tfsec](https://aquasecurity.github.io/tfsec), when `install-tfsec=true` (default = `false`), using provided `tfsec-version` input (default = `1.28.0`)
+- [tfsec](https://aquasecurity.github.io/tfsec), when `install-tfsec=true` (default = `false`), using provided `tfsec-version` input (default = `1.28.14`)
 - [trivy](https://aquasecurity.github.io/trivy), when `install-trivy=true` (default = `false`), using provided `trivy-version` input (default = `0.65.0`)
-- [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit=true` (default = `false`), using provided `hcledit-version` input (default = `0.2.3`)
+- [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit=true` (default = `false`), using provided `hcledit-version` input (default = `0.2.17`)
 
 #### Example
 

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -15,6 +15,7 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 - [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input
 - [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit` is `true` (and `hcledit-version` to support)
 - [tfsec](https://github.com/aquasecurity/tfsec)
+- [trivy](https://github.com/aquasecurity/trivy)
 
 ```yml
 jobs:

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -138,11 +138,13 @@ runs:
         sudo tar -xzf tfsec.tar.gz -C /usr/bin/ tfsec tfsec-checkgen
         rm tfsec.tar.gz 2> /dev/null
 
-        if [[ "${{ inputs.install-trivy }}" == "true" ]]; then
-          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.TRIVY_OS }}-${{ env.TRIVY_ARCH }}.tar.gz
-          sudo tar -xzf trivy.tar.gz -C /usr/bin/ trivy
-          rm trivy.tar.gz 2> /dev/null
-        fi
+    - name: Install trivy
+      shell: bash
+      if: ${{ inputs.install-trivy == 'true' }}
+      run: |
+        curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.TRIVY_OS }}-${{ env.TRIVY_ARCH }}.tar.gz
+        sudo tar -xzf trivy.tar.gz -C /usr/bin/ trivy
+        rm trivy.tar.gz 2> /dev/null
 
     - name: Execute pre-commit
       shell: bash

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -139,7 +139,7 @@ runs:
         rm tfsec.tar.gz 2> /dev/null
 
         if [[ "${{ inputs.install-trivy }}" == "true" ]]; then
-          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.TRIVY_OS }}_${{ env.TRIVY_ARCH }}.tar.gz
+          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.TRIVY_OS }}-${{ env.TRIVY_ARCH }}.tar.gz
           sudo tar -xzf trivy.tar.gz -C /usr/bin/ trivy
           rm trivy.tar.gz 2> /dev/null
         fi

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -32,6 +32,14 @@ inputs:
     description: Version of tfsec to install when `install-tfsec` is true
     required: false
     default: 1.28.14
+  install-trivy:
+    description: Install trivy for pre-commit
+    required: false
+    default: 'false'
+  trivy-version:
+    description: Version of trivy to install when `install-trivy` is true
+    required: false
+    default: 0.65.0
 
 runs:
   using: composite
@@ -110,6 +118,12 @@ runs:
         curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./tfsec.tar.gz https://github.com/aquasecurity/tfsec/releases/download/v${{ inputs.tfsec-version }}/tfsec_${{ inputs.tfsec-version }}_${{ env.OS }}_${{ env.ARCH }}.tar.gz
         sudo tar -xzf tfsec.tar.gz -C /usr/bin/ tfsec tfsec-checkgen
         rm tfsec.tar.gz 2> /dev/null
+
+        if [[ "${{ inputs.install-trivy }}" == "true" ]]; then
+          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.OS }}_${{ env.ARCH }}.tar.gz
+          sudo tar -xzf trivy.tar.gz -C /usr/bin/ trivy
+          rm trivy.tar.gz 2> /dev/null
+        fi
 
     - name: Execute pre-commit
       shell: bash

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -49,23 +49,42 @@ runs:
       shell: bash
       run: |
         os=$(uname -s | tr '[:upper:]' '[:lower:]')
+        case "$os" in
+            linux)
+                trivy_os="Linux"
+                ;;
+            darwin)
+                trivy_os="macOS"
+                ;;
+            windows)
+                trivy_os="Windows"
+                ;;
+        esac
+
         arch=$(uname -m)
         case $arch in
             "x86_64")
                 arch="amd64"
+                trivy_arch="64bit"
                 ;;
             "i386" | "i686")
                 arch="386"
+                trivy_arch="32bit"
                 ;;
             "aarch64")
                 arch="arm64"
+                trivy_arch="ARM64"
                 ;;
             "armv7l")
                 arch="arm"
+                trivy_arch="ARM"
                 ;;
         esac
+
         echo "OS=$os" >> $GITHUB_ENV
         echo "ARCH=$arch" >> $GITHUB_ENV
+        echo "TRIVY_OS=$trivy_os" >> $GITHUB_ENV
+        echo "TRIVY_ARCH=$trivy_arch" >> $GITHUB_ENV
 
     - name: Install Terraform v${{ inputs.terraform-version }}
       shell: bash
@@ -120,7 +139,7 @@ runs:
         rm tfsec.tar.gz 2> /dev/null
 
         if [[ "${{ inputs.install-trivy }}" == "true" ]]; then
-          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.OS }}_${{ env.ARCH }}.tar.gz
+          curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_${{ env.TRIVY_OS }}_${{ env.TRIVY_ARCH }}.tar.gz
           sudo tar -xzf trivy.tar.gz -C /usr/bin/ trivy
           rm trivy.tar.gz 2> /dev/null
         fi


### PR DESCRIPTION
## Description
Add trivy as optional dependency

## Motivation and Context
Trivy is replacement for tfsec and will be more maintained in the future: https://github.com/aquasecurity/tfsec?tab=readme-ov-file#-tfsec-to-trivy-migration

## How Has This Been Tested?
Used fork in my private repositories and so far everything works as expected.

## Screenshots (if appropriate):
