### PR TITLE
fix(pre-commit): replace setup-opentofu with shell install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,27 +58,38 @@ jobs:
 
 The `clowdhaus/terraform-composite-actions/pre-commit` action will install the following tools which are intended to support the pre-commit hooks used within Terraform modules:
 
-#### Default
+#### Default Tools
 
 - [pre-commit](https://github.com/pre-commit/pre-commit)
-- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required when `use-opentofu=false`)
+- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required when `use-opentofu` is `false`)
 - [tflint](https://github.com/terraform-linters/tflint) using provided `tflint-version` input (default = `latest`)
 - [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input (default = `v0.20.0`)
 
 #### OpenTofu Support
 
-- [OpenTofu](https://opentofu.org/) can be used instead of Terraform by setting `use-opentofu: true`
-- When enabled, OpenTofu is installed using the official [opentofu/setup-opentofu](https://github.com/opentofu/setup-opentofu) action
-- The `PCT_TFPATH` environment variable is automatically set to ensure pre-commit hooks use `tofu` instead of `terraform`
-- Use `opentofu-version` input to specify the version (default = `1.11.0`)
+This action supports [OpenTofu](https://opentofu.org/) as a drop-in replacement for Terraform. When using OpenTofu:
 
-#### Optional
+- Set `use-opentofu: true` to enable OpenTofu instead of Terraform
+- Specify the OpenTofu version with `opentofu-version` input (default = `1.11.4`)
+- OpenTofu is installed via the official [opentofu/setup-opentofu](https://github.com/opentofu/setup-opentofu) action
+- The action automatically sets `PCT_TFPATH=tofu` to ensure [pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) hooks use the `tofu` binary
+- Terraform installation is skipped when `use-opentofu` is enabled
+
+**Key Parameters:**
+
+- `use-opentofu`: Boolean flag to use OpenTofu instead of Terraform (default: `false`)
+- `opentofu-version`: OpenTofu version to install when `use-opentofu` is `true` (default: `1.11.4`)
+- `terraform-version`: Required when `use-opentofu` is `false`; the action validates this requirement
+
+#### Optional Tools
 
 - [tfsec](https://aquasecurity.github.io/tfsec), when `install-tfsec=true` (default = `false`), using provided `tfsec-version` input (default = `1.28.14`)
 - [trivy](https://aquasecurity.github.io/trivy), when `install-trivy=true` (default = `false`), using provided `trivy-version` input (default = `0.65.0`)
 - [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit=true` (default = `false`), using provided `hcledit-version` input (default = `0.2.17`)
 
-#### Example (Terraform)
+#### Usage Examples
+
+##### Example: Terraform
 
 ```yml
 jobs:
@@ -86,19 +97,25 @@ jobs:
     name: Pre-commit hooks execute
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run pre-commit with Terraform
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
-          # Configure default software
+          # Terraform configuration
           terraform-version: 1.2.0
+          # Tool versions
           terraform-docs-version: v0.16.0
-          # Configure optional software
+          tflint-version: latest
+          # Optional tools
           install-hcledit: true
           hcledit-version: 0.2.3
+          # Pre-commit arguments
           args: "--all-files --color always --show-diff-on-failure"
 ```
 
-#### Example (OpenTofu)
+##### Example: OpenTofu
 
 ```yml
 jobs:
@@ -106,16 +123,71 @@ jobs:
     name: Pre-commit hooks execute
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run pre-commit with OpenTofu
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
-          # Use OpenTofu instead of Terraform
+          # Enable OpenTofu (replaces Terraform)
           use-opentofu: true
-          opentofu-version: 1.11.0
-          # Configure other software
+          opentofu-version: 1.11.4
+          # Tool versions (same as Terraform workflow)
+          terraform-docs-version: v0.20.0
+          tflint-version: latest
+          # Pre-commit arguments
+          args: "--all-files --color always --show-diff-on-failure"
+```
+
+**Note:** When `use-opentofu: true` is set:
+- The `terraform-version` input is ignored and not required
+- All pre-commit hooks that would normally use `terraform` will automatically use `tofu` via the `PCT_TFPATH` environment variable
+- The workflow is otherwise identical to the Terraform example
+
+##### Example: OpenTofu with Optional Security Scanning
+
+```yml
+jobs:
+  pre-commit:
+    name: Pre-commit hooks execute with security scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run pre-commit with OpenTofu and security tools
+        uses: clowdhaus/terraform-composite-actions/pre-commit@main
+        with:
+          # OpenTofu configuration
+          use-opentofu: true
+          opentofu-version: 1.11.4
+          # Enable security scanning
+          install-tfsec: true
+          tfsec-version: 1.28.14
+          install-trivy: true
+          trivy-version: 0.65.0
+          # Standard tools
           terraform-docs-version: v0.20.0
           args: "--all-files --color always --show-diff-on-failure"
 ```
+
+#### Inputs Reference
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `use-opentofu` | Use OpenTofu instead of Terraform. When `true`, installs OpenTofu and sets `PCT_TFPATH=tofu` | No | `false` |
+| `opentofu-version` | OpenTofu version to install when `use-opentofu` is `true` | No | `1.11.4` |
+| `terraform-version` | Terraform version to install. Required when `use-opentofu` is `false` | Conditional | N/A |
+| `terraform-docs-version` | Version of terraform-docs to install | No | `v0.20.0` |
+| `tflint-version` | Version of tflint to install | No | `latest` |
+| `install-hcledit` | Whether to install hcledit | No | `false` |
+| `hcledit-version` | Version of hcledit to install when enabled | No | `0.2.17` |
+| `install-tfsec` | Whether to install tfsec for security scanning | No | `false` |
+| `tfsec-version` | Version of tfsec to install when enabled | No | `1.28.14` |
+| `install-trivy` | Whether to install trivy for security scanning | No | `false` |
+| `trivy-version` | Version of trivy to install when enabled | No | `0.65.0` |
+| `parallelize-init` | Whether to parallelize `terraform init` across directories | No | `false` |
+| `args` | Arguments to pass to pre-commit run command | No | `--all-files --color always --show-diff-on-failure` |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,16 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 #### Default
 
 - [pre-commit](https://github.com/pre-commit/pre-commit)
-- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required)
+- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required when `use-opentofu=false`)
 - [tflint](https://github.com/terraform-linters/tflint) using provided `tflint-version` input (default = `latest`)
 - [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input (default = `v0.20.0`)
+
+#### OpenTofu Support
+
+- [OpenTofu](https://opentofu.org/) can be used instead of Terraform by setting `use-opentofu: true`
+- When enabled, OpenTofu is installed using the official [opentofu/setup-opentofu](https://github.com/opentofu/setup-opentofu) action
+- The `PCT_TFPATH` environment variable is automatically set to ensure pre-commit hooks use `tofu` instead of `terraform`
+- Use `opentofu-version` input to specify the version (default = `1.11.0`)
 
 #### Optional
 
@@ -71,7 +78,7 @@ The `clowdhaus/terraform-composite-actions/pre-commit` action will install the f
 - [trivy](https://aquasecurity.github.io/trivy), when `install-trivy=true` (default = `false`), using provided `trivy-version` input (default = `0.65.0`)
 - [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit=true` (default = `false`), using provided `hcledit-version` input (default = `0.2.17`)
 
-#### Example
+#### Example (Terraform)
 
 ```yml
 jobs:
@@ -79,16 +86,34 @@ jobs:
     name: Pre-commit hooks execute
     runs-on: ubuntu-latest
     steps:
-      - name: Sign AWS Lambda artifact
+      - name: Run pre-commit with Terraform
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
           # Configure default software
           terraform-version: 1.2.0
           terraform-docs-version: v0.16.0
-          terraform-architecture: amd64
           # Configure optional software
           install-hcledit: true
           hcledit-version: 0.2.3
+          args: "--all-files --color always --show-diff-on-failure"
+```
+
+#### Example (OpenTofu)
+
+```yml
+jobs:
+  pre-commit:
+    name: Pre-commit hooks execute
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pre-commit with OpenTofu
+        uses: clowdhaus/terraform-composite-actions/pre-commit@main
+        with:
+          # Use OpenTofu instead of Terraform
+          use-opentofu: true
+          opentofu-version: 1.11.0
+          # Configure other software
+          terraform-docs-version: v0.20.0
           args: "--all-files --color always --show-diff-on-failure"
 ```
 

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -9,13 +9,23 @@
 
 The `clowdhaus/terraform-composite-actions/pre-commit` action will install the following tools which are intended to support the pre-commit hooks used within Terraform modules:
 
-- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input
+### Default Tools
+
+- [terraform](https://github.com/hashicorp/terraform) using provided `terraform-version` input (required when `use-opentofu` is `false`)
+- [OpenTofu](https://opentofu.org/) using provided `opentofu-version` input when `use-opentofu` is `true`
 - [pre-commit](https://github.com/pre-commit/pre-commit)
-- [tflint](https://github.com/terraform-linters/tflint)
+- [tflint](https://github.com/terraform-linters/tflint) using provided `tflint-version` input
 - [terraform-docs](https://github.com/terraform-docs/terraform-docs) using provided `terraform-docs-version` input
-- [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit` is `true` (and `hcledit-version` to support)
-- [tfsec](https://github.com/aquasecurity/tfsec)
-- [trivy](https://github.com/aquasecurity/trivy)
+
+### Optional Tools
+
+- [hcledit](https://github.com/minamijoyo/hcledit) when `install-hcledit` is `true` (using `hcledit-version`)
+- [tfsec](https://github.com/aquasecurity/tfsec) when `install-tfsec` is `true` (using `tfsec-version`)
+- [trivy](https://github.com/aquasecurity/trivy) when `install-trivy` is `true` (using `trivy-version`)
+
+## Examples
+
+### Terraform
 
 ```yml
 jobs:
@@ -23,13 +33,58 @@ jobs:
     name: Pre-commit hooks execute
     runs-on: ubuntu-latest
     steps:
-      - name: Sign AWS Lambda artifact
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run pre-commit with Terraform
         uses: clowdhaus/terraform-composite-actions/pre-commit@main
         with:
           terraform-version: 1.2.0
-          terraform-docs-version: v16.0.0
-          terraform-architecture: amd64
+          terraform-docs-version: v0.16.0
           install-hcledit: true
           hcledit-version: 0.2.3
           args: "--all-files --color always --show-diff-on-failure"
 ```
+
+### OpenTofu
+
+```yml
+jobs:
+  pre-commit:
+    name: Pre-commit hooks execute
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run pre-commit with OpenTofu
+        uses: clowdhaus/terraform-composite-actions/pre-commit@main
+        with:
+          use-opentofu: true
+          opentofu-version: 1.11.4
+          terraform-docs-version: v0.20.0
+          args: "--all-files --color always --show-diff-on-failure"
+```
+
+When `use-opentofu: true`:
+- OpenTofu is installed via the official [opentofu/setup-opentofu](https://github.com/opentofu/setup-opentofu) action
+- `PCT_TFPATH=tofu` is set to ensure [pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) hooks use the `tofu` binary
+- `terraform-version` is not required
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `use-opentofu` | Use OpenTofu instead of Terraform | No | `false` |
+| `opentofu-version` | OpenTofu version to install when `use-opentofu` is `true` | No | `1.11.4` |
+| `terraform-version` | Terraform version to install. Required when `use-opentofu` is `false` | Conditional | N/A |
+| `terraform-docs-version` | Version of terraform-docs to install | No | `v0.20.0` |
+| `tflint-version` | Version of tflint to install | No | `latest` |
+| `install-hcledit` | Whether to install hcledit | No | `false` |
+| `hcledit-version` | Version of hcledit to install when enabled | No | `0.2.17` |
+| `install-tfsec` | Whether to install tfsec | No | `false` |
+| `tfsec-version` | Version of tfsec to install when enabled | No | `1.28.14` |
+| `install-trivy` | Whether to install trivy | No | `false` |
+| `trivy-version` | Version of trivy to install when enabled | No | `0.65.0` |
+| `parallelize-init` | Whether to parallelize `terraform init` across directories | No | `false` |
+| `args` | Arguments to pass to pre-commit run command | No | `--all-files --color always --show-diff-on-failure` |

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -51,11 +51,19 @@ inputs:
   opentofu-version:
     description: 'The version of OpenTofu to install when use-opentofu is true'
     required: false
-    default: '1.11.0'
+    default: '1.11.4'
 
 runs:
   using: composite
   steps:
+    - name: Validate version inputs
+      shell: bash
+      run: |
+        if [[ "${{ inputs.use-opentofu }}" != "true" && -z "${{ inputs.terraform-version }}" ]]; then
+          echo "::error::terraform-version is required when use-opentofu is false"
+          exit 1
+        fi
+
     - name: Determine OS and Architecture
       id: os_arch
       shell: bash

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -146,10 +146,11 @@ runs:
 
     - name: Install OpenTofu v${{ inputs.opentofu-version }}
       if: inputs.use-opentofu == 'true'
-      uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
-      with:
-        tofu_version: ${{ inputs.opentofu-version }}
-        tofu_wrapper: false
+      shell: bash
+      run: |
+        curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./tofu.zip "https://github.com/opentofu/opentofu/releases/download/v${{ inputs.opentofu-version }}/tofu_${{ inputs.opentofu-version }}_${{ env.OS }}_${{ env.ARCH }}.zip"
+        sudo unzip -qq tofu.zip tofu -d /usr/bin/
+        rm tofu.zip 2> /dev/null
 
     - name: Set PCT_TFPATH for OpenTofu
       if: inputs.use-opentofu == 'true'

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -2,8 +2,8 @@ name: pre-commit
 description: Execute pre-commit for Terraform codebase
 inputs:
   terraform-version:
-    description: Terraform version supported for use in evaluation
-    required: true
+    description: Terraform version supported for use in evaluation. Required when use-opentofu is false.
+    required: false
   terraform-docs-version:
     description: Version of terraform-docs to use when evaluating checks
     required: false
@@ -44,6 +44,14 @@ inputs:
     description: Whether to parallelize 'terraform init' across directories
     required: false
     default: 'false'
+  use-opentofu:
+    description: 'Use OpenTofu instead of Terraform. When true, installs OpenTofu and sets PCT_TFPATH to ensure pre-commit hooks use tofu.'
+    required: false
+    default: 'false'
+  opentofu-version:
+    description: 'The version of OpenTofu to install when use-opentofu is true'
+    required: false
+    default: '1.11.0'
 
 runs:
   using: composite
@@ -128,7 +136,20 @@ runs:
         echo "TRIVY_ARCH=$trivy_arch" >> $GITHUB_ENV
         echo "RG_TARGET=$rg_target" >> $GITHUB_ENV
 
+    - name: Install OpenTofu v${{ inputs.opentofu-version }}
+      if: inputs.use-opentofu == 'true'
+      uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+      with:
+        tofu_version: ${{ inputs.opentofu-version }}
+        tofu_wrapper: false
+
+    - name: Set PCT_TFPATH for OpenTofu
+      if: inputs.use-opentofu == 'true'
+      shell: bash
+      run: echo "PCT_TFPATH=tofu" >> $GITHUB_ENV
+
     - name: Install Terraform v${{ inputs.terraform-version }}
+      if: inputs.use-opentofu != 'true'
       shell: bash
       run: |
         rm -rf $(which terraform)
@@ -197,7 +218,8 @@ runs:
         mv ripgrep-15.0.0-${{ env.RG_TARGET }}/rg /usr/local/bin/
         rm -rf ripgrep* 2> /dev/null
         DIRS=$(rg -l -ttf --null required_version . | xargs -0 dirname | uniq)
-        echo "$DIRS" | xargs -n 1 -P 4 -I {} bash -c 'cd "{}" && terraform init -input=false -no-color || true'
+        INIT_CMD="${PCT_TFPATH:-terraform}"
+        echo "$DIRS" | xargs -n 1 -P 4 -I {} bash -c 'cd "{}" && '"$INIT_CMD"' init -input=false -no-color || true'
 
     - name: Execute pre-commit
       shell: bash


### PR DESCRIPTION
## Summary
- Replaces `opentofu/setup-opentofu@v1` (node20) with a shell-based curl+unzip install in `pre-commit/action.yml`
- Eliminates node20 dependency ahead of GitHub's June 2, 2026 node24 enforcement
- New install pattern matches the existing Terraform install step in the same file

## Context
The `opentofu/setup-opentofu` action (v1.0.8, latest) still uses **node20** with no upstream node24-compatible release — only an [open issue (#90)](https://github.com/opentofu/setup-opentofu/issues/90). Our usage is minimal (`tofu_version` + `tofu_wrapper: false`), so a shell install is a clean drop-in replacement.

The `OS` and `ARCH` env vars are already set by the "Determine OS and Architecture" step earlier in the composite action.

## JIRA
INFRA-2164

## Test plan
- [ ] CI runs `pre-commit.yml` which exercises this composite action with `use-opentofu: true`
- [ ] Verify no node20 deprecation warnings in CI output
- [ ] After merge, update `reusable-gh-actions` to point to the new version/ref (separate follow-up)