### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get root directories
         id: dirs
@@ -33,11 +33,11 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v3.0.1
+        uses: clowdhaus/terraform-min-max@5e40f8cf535d84fbd031571abd363ffd81dbfbfc # v3.0.1
         with:
           directory: ${{ matrix.directory }}
 
@@ -68,14 +68,14 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v3.0.1
+        uses: clowdhaus/terraform-min-max@5e40f8cf535d84fbd031571abd363ffd81dbfbfc # v3.0.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: ./pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.20.0
-  TFLINT_VERSION: v0.59.1
+  TERRAFORM_DOCS_VERSION: v0.24.0
+  TFLINT_VERSION: v0.62.1
 
 jobs:
   collectInputs:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
         with:
           directory: ${{ matrix.directory }}
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: ./pre-commit

--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.0
+    rev: v1.106.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -7,7 +7,7 @@ inputs:
   terraform-docs-version:
     description: Version of terraform-docs to use when evaluating checks
     required: false
-    default: v0.20.0
+    default: v0.24.0
   tflint-version:
     description: Version of tflint to use when evaluating checks
     required: false
@@ -23,7 +23,7 @@ inputs:
   hcledit-version:
     description: Version of hcledit to install when `install-hcledit` is true
     required: false
-    default: 0.2.17
+    default: 0.2.18
   install-tfsec:
     description: Install tfsec for pre-commit
     required: false
@@ -39,7 +39,7 @@ inputs:
   trivy-version:
     description: Version of trivy to install when `install-trivy` is true
     required: false
-    default: 0.65.0
+    default: 0.71.0
   parallelize-init:
     description: Whether to parallelize 'terraform init' across directories
     required: false
@@ -192,9 +192,9 @@ runs:
       shell: bash
       if: ${{ inputs.parallelize-init == 'true' }}
       run: |
-        curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./ripgrep.tar.gz https://github.com/BurntSushi/ripgrep/releases/download/15.0.0/ripgrep-15.0.0-${{ env.RG_TARGET }}.tar.gz
+        curl --retry 3 --retry-all-errors --retry-delay 3 -sSLo ./ripgrep.tar.gz https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-${{ env.RG_TARGET }}.tar.gz
         tar -xzf ripgrep.tar.gz
-        mv ripgrep-15.0.0-${{ env.RG_TARGET }}/rg /usr/local/bin/
+        mv ripgrep-15.1.0-${{ env.RG_TARGET }}/rg /usr/local/bin/
         rm -rf ripgrep* 2> /dev/null
         DIRS=$(rg -l -ttf --null required_version . | xargs -0 dirname | uniq)
         echo "$DIRS" | xargs -n 1 -P 4 -I {} bash -c 'cd "{}" && terraform init -input=false -no-color || true'


### PR DESCRIPTION
Bumps to latest including a major on terraform-min-max, and pins all third-party actions to commit SHAs to satisfy the org's required-SHA-pinning policy (the floating `@v6` short tags currently on `main` were rejected by CI as soon as a new PR ran).

- clowdhaus/terraform-min-max v2.1.0 → v3.0.1
- actions/checkout @v6 → v6.0.2 (SHA-pinned)
- actions/setup-node @v6 → v6.4.0 (SHA-pinned)
- antonbabenko/pre-commit-terraform v1.100.0 → v1.106.0
- terraform-docs v0.20.0 → v0.24.0
- tflint v0.59.1 → v0.62.1
- trivy 0.65.0 → 0.71.0
- ripgrep 15.0.0 → 15.1.0
- hcledit 0.2.17 → 0.2.18

terraform-min-max v3 is a major release ("Codebase overhaul - modernize tooling, harden security, improve quality") but the action interface — inputs (`directory`), outputs (`minVersion`, `maxVersion`), and `node24` runtime — is unchanged from v2.1.0, so no workflow edits needed.

Supersedes #46.